### PR TITLE
@joeyAghion => Use S3 key from Gemini response, vs client options

### DIFF
--- a/gemup.js
+++ b/gemup.js
@@ -39,7 +39,7 @@
         var data = {
           'Content-Type': 'image/png',
           key: res.policy_document.conditions[1][2] + "/${filename}",
-          AWSAccessKeyId: options.key,
+          AWSAccessKeyId: res.credentials,
           acl: 'public-read',
           success_action_status: res.policy_document.conditions[3].success_action_status,
           policy: res.policy_encoded,


### PR DESCRIPTION
Same fix as https://github.com/artsy/gemini_upload-rails/pull/17