### PR TITLE
@mzikherman: Release as @artsy/gemup and v0.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "gemup",
-  "version": "0.0.2",
+  "name": "@artsy/gemup",
+  "version": "0.0.3",
   "description": "Lightweight Javascript utility for using Artsy's Gemini service to upload directly to S3.",
   "keywords": [
     "gemup",


### PR DESCRIPTION
As discussed, let's release this under `@artsy`. Though not _strictly_ necessary, I bumped the version number as well to avoid confusion with the already-released and un-scoped v0.0.2.

This is already available here: https://www.npmjs.com/package/@artsy/gemup