### PR TITLE
Allow geminiHost to be passed in as an option

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ $('#my-uploader').on('change', function(e) {
   gemup(e.target.files[0],{
     app: 'force',
     key: 'SECRET_GEMINI_S3_KEY',
+    geminiHost: 'https://media.artsy.net',
     fail: function(err) {
       console.log("Ouch!", err);
     },

--- a/gemup.js
+++ b/gemup.js
@@ -6,6 +6,7 @@
     var defaults = {
       acl: 'public-read',
       app: 'force',
+      geminiHost: 'https://media.artsy.net',
       add: function(){},
       progress: function(){},
       done: function(){},
@@ -25,7 +26,7 @@
     // Get S3 credentials from Gemini
     var key = key = btoa(unescape(encodeURIComponent(options.app + ':')));
     $.ajax({
-      url: 'https://media.artsy.net/uploads/new.json',
+      url: options.geminiHost + '/uploads/new.json',
       data: {
         acl: options.acl
       },

--- a/test/example.html
+++ b/test/example.html
@@ -8,6 +8,7 @@
         gemup(e.target.files[0],{
           app: 'force',
           key: 'SECRET_GEMINI_S3_KEY',
+          geminiHost: 'https://media.artsy.net',
           fail: function(err) {
             console.log("Ouch!", err);
           },


### PR DESCRIPTION
Should allow for us to use gemup pointing to Gemini-staging or to Gemini running locally during development.