### PR TITLE
Remove examples of `options.key`

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ Upload some files to S3 when someone changes it.
 $('#my-uploader').on('change', function(e) {
   gemup(e.target.files[0],{
     app: 'force',
-    key: 'SECRET_GEMINI_S3_KEY',
     fail: function(err) {
       console.log("Ouch!", err);
     },

--- a/test/example.html
+++ b/test/example.html
@@ -7,7 +7,6 @@
       $('#my-uploader').on('change', function(e) {
         gemup(e.target.files[0],{
           app: 'force',
-          key: 'SECRET_GEMINI_S3_KEY',
           fail: function(err) {
             console.log("Ouch!", err);
           },


### PR DESCRIPTION
A `key` option doesn't seem to be used in the gemup code. Might be leftover from before we were constructing the S3 key using the Gemini token and filename.