### PR TITLE
Use filetype of image instead of hardcoding to image/png

### DIFF
--- a/gemup.js
+++ b/gemup.js
@@ -40,7 +40,7 @@
         var geminiKey = res.policy_document.conditions[1][2]
         var bucket = res.policy_document.conditions[0].bucket
         var data = {
-          'Content-Type': 'image/png',
+          'Content-Type': file.type,
           key: geminiKey + "/${filename}",
           AWSAccessKeyId: res.credentials,
           acl: options.acl,


### PR DESCRIPTION
Rely on the File Web API to determine the mime type of a file based on its file extension.

https://developer.mozilla.org/en-US/docs/Web/API/File/type