### PR TITLE
Release version v0.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@artsy/gemup",
-  "version": "0.0.3",
+  "version": "0.1.0",
   "description": "Lightweight Javascript utility for using Artsy's Gemini service to upload directly to S3.",
   "keywords": [
     "gemup",


### PR DESCRIPTION
- Make this exportable and fix default option naming (#14)
- Allow storing with original filename but set to false by default (#12)
- Allow geminiHost to be passed in as an option (#8)
- [docs] Remove examples of `options.key` (#9)
- Use filetype of image instead of hardcoding to image/png (#10)
- [docs] Update README (#7)