### PR TITLE
refactor(no-deps): Refactors gemup to not rely on jquery

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ yarn add @artsy/gemup
 Import into your project:
 
 ```javascript
-// Note you DO NOT need { } around the import!!
 import gemup from "@artsy/gemup";
 ```
 
@@ -49,41 +48,6 @@ const handleUploadClick = (e) => {
 
 <input type="file" multiple={false} onChange={(e) => handleUploadClick(e)} />
 ```
-
-### Using jQuery
-
-Use a file input:
-
-```html
-<input id="my-uploader" type="file" multiple="" />
-```
-
-Upload some files to S3 when someone changes it.
-
-```js
-$("#my-uploader").on("change", function (e) {
-  gemup(e.target.files[0], {
-    app: "force",
-    geminiHost: 'https://media.artsy.net',
-    fail: function (err) {
-      console.log("Ouch!", err);
-    },
-    add: function (src) {
-      console.log("We got a data-uri image client-side!", src);
-    },
-    progress: function (percent) {
-      console.log("<3 progress bars, file is this % uploaded: ", percent);
-    },
-    done: function (src) {
-      console.log("Done uploading, here's the S3 url: ", src);
-    },
-  });
-});
-```
-
-## Notes
-
-Currently only works with jQuery 2.x available globally—but hopefully dropping that dependency down the line.
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@artsy/gemup",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Lightweight Javascript utility for using Artsy's Gemini service to upload directly to S3.",
   "keywords": [
     "gemup",

--- a/test/example.html
+++ b/test/example.html
@@ -1,10 +1,9 @@
 <html>
   <body>
     <input id="my-uploader" type="file" multiple="">
-    <script type="text/javascript" src="http://code.jquery.com/jquery-2.1.1.min.js"></script>
     <script type="text/javascript" src="../gemup.js"></script>
     <script type="text/javascript">
-      $('#my-uploader').on('change', function(e) {
+      document.getElementById('my-uploader').addEventListener('change', function(e) {
         gemup(e.target.files[0],{
           app: 'force',
           geminiHost: 'https://media.artsy.net',


### PR DESCRIPTION
Noticed that Volt2 was failing on image uploads, and the culprit came from here -- we were implicitly using jQuery, but we don't have to anymore. 

Test output: 

<img width="616" alt="Screenshot 2023-12-14 at 2 07 43 PM" src="https://github.com/artsy/gemup/assets/236943/c7085784-d374-4a67-a4c3-cbf09ed46ea2">
